### PR TITLE
Moved didMoveToParentViewController inside of completion block

### DIFF
--- a/GHSidebarNav/GHRevealViewController.m
+++ b/GHSidebarNav/GHRevealViewController.m
@@ -57,10 +57,10 @@ const CGFloat kGHRevealSidebarFlickVelocity = 1000.0f;
 								completion:^(BOOL finished){
 									self.view.userInteractionEnabled = YES;
 									[sidebarViewController removeFromParentViewController];
+									[svc didMoveToParentViewController:self];
 									sidebarViewController = svc;
 								}
 		 ];
-		[sidebarViewController didMoveToParentViewController:self];
 	}
 }
 
@@ -84,10 +84,10 @@ const CGFloat kGHRevealSidebarFlickVelocity = 1000.0f;
 								completion:^(BOOL finished){
 									self.view.userInteractionEnabled = YES;
 									[contentViewController removeFromParentViewController];
+									[cvc didMoveToParentViewController:self];
 									contentViewController = cvc;
 								}
 		];
-		[contentViewController didMoveToParentViewController:self];
 	}
 }
 


### PR DESCRIPTION
There isn't much in the way of documentation or examples yet on Custom Container View Controllers but I think this call should to be inside the completion handler.

-Jesse
